### PR TITLE
Bumping for re-release due to 0.2.11 re-release made in upstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <packaging>jar</packaging>
   <groupId>org.webjars</groupId>
   <artifactId>angular-ui-router</artifactId>
-  <version>0.2.12-SNAPSHOT</version>
+  <version>0.2.11-2-SNAPSHOT</version>
   <name>Angular UI Router</name>
   <description>WebJar for Angular UI Router</description>
   <url>http://webjars.org</url>


### PR DESCRIPTION
According to the change-log of upstream there has been a re-release of 0.2.11
I've compared the code diff of what's available in webjars and the changes made in this upstream commit: https://github.com/angular-ui/ui-router/commit/ee292fdfa62c348b2198a71edba3507199e78b81

It seems webjar needs to be refreshed
